### PR TITLE
DOCS: correct description of top_k parameter in function docstring

### DIFF
--- a/desp/DESP.py
+++ b/desp/DESP.py
@@ -100,7 +100,7 @@ class DESP:
             iteration_limit (int, optional): The maximum number of iterations for the search. Defaults to 500.
             top_n (int, optional): The number of top nodes to keep in the top-down search. Defaults to 50.
             top_m (int, optional): The number of top nodes to keep in the bottom-up search. Defaults to 25.
-            top_k (int, optional): The number of top routes to keep in the final solution. Defaults to 2.
+            top_k (int, optional): The number of top building blocks to consider for each bimolecular reaction. Defaults to 2.
             max_depth_top (int, optional): The maximum depth for the top-down search. Defaults to 21, which corresponds
                                            to a max depth of 11 molecule nodes.
             max_depth_bot (int, optional): The maximum depth for the bottom-up search. Defaults to 11, which corresponds


### PR DESCRIPTION
Thank you so much for sharing the code for DESP, and congratulations on the acceptance to NeurIPS 2024!

While exploring the package, I noticed that the `top_k` parameter was described as "The number of top routes to keep in the final solution" in [desp/DESP.py](https://github.com/coleygroup/desp/blob/main/desp/DESP.py), but it seems to refer to the number of top building blocks to consider for each bimolecular reaction. To clarify, I’ve updated the docstring to reflect this.

Additionally, I believe an enhancement that allows for returning more than just the top 1 route in the final solution (as the original description suggests) could be a valuable feature to consider for future updates.

Thanks again for the great work!